### PR TITLE
More In-Depth Handling of Job Progress and Detail

### DIFF
--- a/src/main/java/de/bitzeche/video/transcoding/zencoder/IZencoderClient.java
+++ b/src/main/java/de/bitzeche/video/transcoding/zencoder/IZencoderClient.java
@@ -36,6 +36,7 @@ public interface IZencoderClient {
 	 * Send a jobProgress request for a job.
 	 * @param jobId ID for the requested job.
 	 * @return State of job, or null if unable to parse response.
+	 * @deprecated use {@link #getJobState(int)}
 	 */
 	public ZencoderNotificationJobState jobProgress(int jobId);
 	
@@ -43,9 +44,52 @@ public interface IZencoderClient {
 	 * Send a jobProgress request for a job.
 	 * @param job
 	 * @return State of job, or null if unable to parse response.
+	 * @deprecated use {@link #getJobState(ZencoderJob)}
 	 */
 	public ZencoderNotificationJobState jobProgress(ZencoderJob job);
-	
+
+	/**
+	 * Send a job detail request for a job.
+	 * @param jobId ID for the requested job.
+	 * @return XML Response from zencoder
+	 */
+	public Document getJobDetails(int jobId);
+
+	/**
+	 * Send a job detail request for a job.
+	 * @param job
+	 * @return XML Response from zencoder
+	 */
+	public Document getJobDetails(ZencoderJob job);
+
+	/**
+	 * Send a jobProgress request for a job.
+	 * @param jobId ID for the requested job.
+	 * @return State of job, or null if unable to parse response.
+	 */
+	public Document getJobProgress(int jobId);
+
+	/**
+	 * Send a jobProgress request for a job.
+	 * @param job
+	 * @return State of job, or null if unable to parse response.
+	 */
+	public Document getJobProgress(ZencoderJob job);
+
+	/**
+	 * Send a jobProgress request to determine the state of a job.
+	 * @param jobId ID for the requested job.
+	 * @return State of job, or null if unable to parse response.
+	 */
+	public ZencoderNotificationJobState getJobState(int jobId);
+
+	/**
+	 * Send a jobProgress request to determine the state of a job.
+	 * @param job
+	 * @return State of job, or null if unable to parse response.
+	 */
+	public ZencoderNotificationJobState getJobState(ZencoderJob job);
+
 	/**
 	 * Send a resubmit request for a job.
 	 * @param jobId ID for the requested job.

--- a/src/main/java/de/bitzeche/video/transcoding/zencoder/ZencoderClient.java
+++ b/src/main/java/de/bitzeche/video/transcoding/zencoder/ZencoderClient.java
@@ -175,13 +175,18 @@ public class ZencoderClient implements IZencoderClient {
 	}
 
 	public ZencoderNotificationJobState jobProgress(int id) {
-		if (zencoderAPIVersion != ZencoderAPIVersion.API_V2) {
-			LOGGER.warn("jobProgress is only available for API v2.  Returning null.");
+		return getJobState(id);
+	}
+
+	public ZencoderNotificationJobState getJobState(ZencoderJob job) {
+		return getJobState(job.getJobId());
+	}
+
+	public ZencoderNotificationJobState getJobState(int id) {
+		Document response = getJobProgress(id);
+		if (response == null) {
 			return null;
 		}
-		String url = zencoderAPIBaseUrl + "jobs/" + id
-				+ "/progress.xml?api_key=" + zencoderAPIKey;
-		Document response = sendGetRequest(url);
 		String stateString = null;
 		try {
 			stateString = (String) xPath.evaluate("/api-response/state",
@@ -193,6 +198,20 @@ public class ZencoderClient implements IZencoderClient {
 			LOGGER.error("XPath threw Exception", e);
 		}
 		return null;
+	}
+
+	public Document getJobProgress(ZencoderJob job) {
+		return getJobProgress(job.getJobId());
+	}
+
+	public Document getJobProgress(int id) {
+		if (zencoderAPIVersion != ZencoderAPIVersion.API_V2) {
+			LOGGER.warn("jobProgress is only available for API v2.  Returning null.");
+			return null;
+		}
+		String url = zencoderAPIBaseUrl + "jobs/" + id
+				+ "/progress.xml?api_key=" + zencoderAPIKey;
+		return sendGetRequest(url);
 	}
 
 	public Document getJobDetails(ZencoderJob job) {


### PR DESCRIPTION
- Added more accurately named getJobState methods (which calls existing jobProgress method) to IZencoderClient and ZencoderClient
- Deprecated existing jobProgress methods in favor of getJobState in IZencoderClient
- Added getJobProgress methods to IZencoderClient and ZencoderClient to expose full job progress response
- Exposed getJobDetails method in IZencoderClient interface
