### PR TITLE
Updated regions and video/audio codec support check

### DIFF
--- a/src/main/java/de/bitzeche/video/transcoding/zencoder/enums/ZencoderRegion.java
+++ b/src/main/java/de/bitzeche/video/transcoding/zencoder/enums/ZencoderRegion.java
@@ -17,5 +17,18 @@
 package de.bitzeche.video.transcoding.zencoder.enums;
 
 public enum ZencoderRegion {
-	EUROPE, US, ASIA;
+	US("us"), EUROPE("europe"), ASIA("asia"), SA("sa"), AUSTRALIA("australia"),
+	VIRGINIA("us-n-virginia"), OREGON("us-oregon"), CALIFORNIA("us-n-california"),
+	DUBLIN("eu-dublin"), SINGAPORE("asia-singapore"), TOKYO("asia-tokyo"),
+	SAOPAULO("sa-saopaulo"), SYDNEY("australia-sydney");
+	
+	private final String regionCode;
+	
+	private ZencoderRegion(String code) {
+		this.regionCode = code;
+	}
+	
+	public String getRegionCode() {
+		return regionCode;
+	}
 }

--- a/src/main/java/de/bitzeche/video/transcoding/zencoder/job/ZencoderJob.java
+++ b/src/main/java/de/bitzeche/video/transcoding/zencoder/job/ZencoderJob.java
@@ -91,7 +91,7 @@ public class ZencoderJob {
 		// region
 		if (this.zencoderRegion != null) {
 			Node region = document.createElement("region");
-			region.setTextContent(this.zencoderRegion.name().toLowerCase());
+			region.setTextContent(this.zencoderRegion.getRegionCode());
 			root.appendChild(region);
 		}
 

--- a/src/main/java/de/bitzeche/video/transcoding/zencoder/job/ZencoderOutput.java
+++ b/src/main/java/de/bitzeche/video/transcoding/zencoder/job/ZencoderOutput.java
@@ -456,17 +456,20 @@ public class ZencoderOutput {
 	}
 
 	public void setAudioCodec(ZencoderAudioCodec codec) {
-		if ((videoCodec.equals(ZencoderVideoCodec.h264) || videoCodec
-				.equals(ZencoderVideoCodec.vp6))
-				&& !(codec.equals(ZencoderAudioCodec.mp3) || codec
-						.equals(ZencoderAudioCodec.aac))) {
+		if ((videoCodec.equals(ZencoderVideoCodec.h264) || videoCodec.equals(ZencoderVideoCodec.vp6)
+				|| videoCodec.equals(ZencoderVideoCodec.mpeg4))
+				&& !(codec.equals(ZencoderAudioCodec.mp3) || codec.equals(ZencoderAudioCodec.aac))) {
 			throw new IllegalArgumentException(
-					"H264 and VP6 only support MP3 or AAC");
+					"H264, MPEG-4 and VP6 only support MP3 or AAC");
 		} else if ((videoCodec.equals(ZencoderVideoCodec.theora) || videoCodec
 				.equals(ZencoderVideoCodec.vp8))
 				&& !codec.equals(ZencoderAudioCodec.vorbis)) {
 			throw new IllegalArgumentException(
-					"H264 and VP8 only support MP3 or AAC");
+					"Theora and VP8 only support Vorbis");
+		} else if (videoCodec.equals(ZencoderVideoCodec.wmv)
+				&& !(codec.equals(ZencoderAudioCodec.wma) || codec.equals(ZencoderAudioCodec.mp3))) {
+			throw new IllegalArgumentException(
+					"WMV only support WMA and MP3");
 		}
 		this.audioCodec = codec;
 	}


### PR DESCRIPTION
- Added all avaiable region to ZencoderRegion enum
  - added the ability to target specific datacenters
  - a little code rewrite here, because `-`are not supported in enums
- updated the check if the audio codec is supported by the choosen video codec
  - fixed typo in exception
  - added check for mpeg4 and wmv
