### PR TITLE
Added read-only api key as an option for progress requests

### DIFF
--- a/src/main/java/de/bitzeche/video/transcoding/zencoder/ZencoderClient.java
+++ b/src/main/java/de/bitzeche/video/transcoding/zencoder/ZencoderClient.java
@@ -63,6 +63,7 @@ public class ZencoderClient implements IZencoderClient {
 	private Client httpClient;
 	private final String zencoderAPIBaseUrl;
 	private final String zencoderAPIKey;
+	private final Strign zencoderReadOnlyAPIKey;
 	private final ZencoderAPIVersion zencoderAPIVersion;
 	private XPath xPath;
 	
@@ -70,11 +71,20 @@ public class ZencoderClient implements IZencoderClient {
 	private int currentConnectionAttempt = 0;
 
 	public ZencoderClient(String zencoderApiKey) {
-		this(zencoderApiKey, ZencoderAPIVersion.API_V1);
+		this(zencoderApiKey, null, ZencoderAPIVersion.API_V1);
+	}
+	
+	public ZencoderClient(String zencdoerApiKey, String zencoderReadOnlyApiKey) {
+		this(zencoderApiKey, zencoderReadOnlyApiKey, ZencoderAPIVersion.API_V1);
+	}
+	
+	public ZencoderClient(String zencoderApiKey, ZencoderAPIVersion apiVersion) {
+		this(zencoderApiKey, null, apiVersion);
 	}
 
-	public ZencoderClient(String zencoderApiKey, ZencoderAPIVersion apiVersion) {
+	public ZencoderClient(String zencoderApiKey, String zencoderReadOnlyApiKey, ZencoderAPIVersion apiVersion) {
 		this.zencoderAPIKey = zencoderApiKey;
+		this.zencoderReadOnlyAPIKey = zencoderReadOnlyApiKey;
 		if (ZencoderAPIVersion.API_DEV.equals(apiVersion)) {
 			LOGGER.warn("!!! Using development version of zencoder API !!!");
 		}
@@ -267,8 +277,10 @@ public class ZencoderClient implements IZencoderClient {
 			LOGGER.warn("jobProgress is only available for API v2.  Returning null.");
 			return null;
 		}
+		String apiKey = zencoderAPIKey;
+		if(zencoderReadOnlyAPIKey != null) apiKey = zencoderReadOnlyAPIKey;
 		String url = zencoderAPIBaseUrl + "jobs/" + id
-				+ "/progress.xml?api_key=" + zencoderAPIKey;
+				+ "/progress.xml?api_key=" + apiKey;
 		Document result = sendGetRequest(url);
 		if(result == null) {
 			currentConnectionAttempt++;
@@ -289,8 +301,10 @@ public class ZencoderClient implements IZencoderClient {
 			LOGGER.error("Reached maximum number of attempts for getting job details. Aborting and returning null");
 			return null;
 		}
+		String apiKey = zencoderAPIKey;
+		if(zencoderReadOnlyAPIKey != null) apiKey = zencoderReadOnlyAPIKey;
 		String url = zencoderAPIBaseUrl + "jobs/" + id + ".xml?api_key="
-				+ zencoderAPIKey;
+				+ apiKey;
 		Document result = sendGetRequest(url);
 		if(result == null) {
 			currentConnectionAttempt++;


### PR DESCRIPTION
For security reasons we do not want to send an api key as part of the url for any requests to Zencoder. On enquiring about this with them we were informed that you can create a read only api key - which can only be used for things like progress requests, and not for creating jobs. This means that even if someone gets hold of it they are unable to abuse our account, merely to try and monitor what we are doing. If this read only key is not set in the constructor then the code behaves as before, using the main api key.
